### PR TITLE
rollback aws version and add joda-time

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -63,7 +63,7 @@
    [clj-stacktrace "0.2.8"]
    [clojure.java-time "0.3.2"]
    [compojure "1.6.1"]
-   [com.amazonaws/aws-java-sdk-s3 "1.11.678"]
+   [com.amazonaws/aws-java-sdk-s3 "1.11.749"]
    [joda-time/joda-time "2.10.5"]
    [com.cemerick/url "0.1.1"
     :exclusions [com.cemerick/clojurescript.test]]

--- a/project.clj
+++ b/project.clj
@@ -63,7 +63,8 @@
    [clj-stacktrace "0.2.8"]
    [clojure.java-time "0.3.2"]
    [compojure "1.6.1"]
-   [com.amazonaws/aws-java-sdk-s3 "1.11.749"]
+   [com.amazonaws/aws-java-sdk-s3 "1.11.678"]
+   [joda-time/joda-time "2.10.5"]
    [com.cemerick/url "0.1.1"
     :exclusions [com.cemerick/clojurescript.test]]
    [com.draines/postal "2.0.3"]


### PR DESCRIPTION
Data object manipulation (upload/download) fails with the latest version of aws-java-sdk-s3 (changes in AWS lib), and joda-time is needed as well.

@0xbase12 Can you please release it as soon as possible? api-server uses parent's releases (not SNAPSHOTs). Thank you!