### PR TITLE
exclude slf4j-log4j12 from zookeeper-clj as it clashes with one provided by the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Exclude slf4j-log4j12 from zookeeper-clj as it clashes with one provided by 
+  the project
+
 ## [6.7.11] - 2022-04-06
 
 - Downgrade to aleph 0.4.6

--- a/project.clj
+++ b/project.clj
@@ -119,7 +119,7 @@
    [ring/ring-json "0.5.1"]
    [ring/ring-defaults "0.3.3"]
 
-   [zookeeper-clj "0.9.4"]
+   [zookeeper-clj "0.9.4" :exclusions [[org.slf4j/slf4j-log4j12]]]
 
    [org.apache.zookeeper/zookeeper "3.8.0"
     :exclusions [ch.qos.logback/logback-classic


### PR DESCRIPTION

Closes #9 